### PR TITLE
use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/plugins/fastly.js
+++ b/plugins/fastly.js
@@ -11,7 +11,7 @@ var Fastly = module.exports = function Fastly(opts)
     this.apikey = opts.apikey;
     this.client = restify.createJSONClient({
         url: 'https://api.fastly.com',
-        headers: { 'x-fastly-key': opts.apikey }
+        headers: { 'fastly-key': opts.apikey }
     });
 };
 


### PR DESCRIPTION
The use of `X-Fastly-Key` is deprecated and will not be supported long term. This branch replaces any occurrences of `X-Fastly-Key` with `Fastly-Key`.